### PR TITLE
replace $ECHO variable with echo command

### DIFF
--- a/check_glusterfs
+++ b/check_glusterfs
@@ -61,7 +61,7 @@ if [ -z "${VOLUME}" -o -z "${BRICKS}" ]; then
 fi
 
 Exit () {
-	$ECHO "$1: ${2:0}"
+	echo "$1: ${2:0}"
 	status=STATE_$1
 	exit ${!status}
 }


### PR DESCRIPTION
Hi

Fixes problem, that output message wants to be executed. E.g.:
`/usr/lib/nagios/plugins/check_glusterfs: line 64: CRITICAL: no bricks found: command not found`

I don't know where this `$ECHO` variable comes from. It's not defined within the script and also not in `utils.sh` from monitoring-plugins-2.0.

Cheers,
ganto
